### PR TITLE
Several improvements

### DIFF
--- a/syntaxes/lexurgy.tmLanguage.json
+++ b/syntaxes/lexurgy.tmLanguage.json
@@ -119,7 +119,7 @@
         },
         "keywords": {
             "name": "keyword.other.lexurgy",
-            "match": "unchanged|explicit|clear"
+            "match": "(^|\\s)(unchanged|explicit|clear)(\\s|$)"
         },
         "constants": {
             "name": "constant.lexurgy",

--- a/syntaxes/lexurgy.tmLanguage.json
+++ b/syntaxes/lexurgy.tmLanguage.json
@@ -9,6 +9,7 @@
         { "include": "#symbol" },
         { "include": "#feature" },
         { "include": "#diacritic" },
+        { "include": "#element" },
         { "include": "#class" },
         { "include": "#class-ref" },
         { "include": "#capture-ref" },
@@ -91,6 +92,10 @@
                 }
             ],
             "end": "\\n"
+        },
+        "element": {
+            "name": "keyword.other.element.lexurgy",
+            "match": "(^|\\s)([Ee]lement)(\\s|$)"
         },
         "rule-name": {
             "name": "entity.name.class.rule-name.lexurgy",

--- a/syntaxes/lexurgy.tmLanguage.json
+++ b/syntaxes/lexurgy.tmLanguage.json
@@ -89,13 +89,31 @@
                 },
                 {
                     "include": "#symbol-list"
+                },
+                {
+                    "include": "#matrix"
+                },
+                {
+                    "include": "#operators"
                 }
             ],
             "end": "(?=#|\\n)"
         },
         "element": {
-            "name": "keyword.other.element.lexurgy",
-            "match": "(^|\\s)([Ee]lement)(\\s|$)"
+            "begin": "^([Ee]lement) ",
+            "beginCaptures": {
+                "1": {
+                    "name": "keyword.other.element.lexurgy"
+                }
+            },
+            "patterns": [{
+                    "include": "#class-name"
+                },
+                {
+                    "include": "#symbol-list"
+                }
+            ],
+            "end": "(?=#|\\n)"
         },
         "rule-name": {
             "name": "entity.name.class.rule-name.lexurgy",

--- a/syntaxes/lexurgy.tmLanguage.json
+++ b/syntaxes/lexurgy.tmLanguage.json
@@ -107,7 +107,7 @@
         },
         "rule-modifier": {
             "name": "storage.modifier.rule-modifier.lexurgy",
-            "match": "([Pp]ropagate|LTR|Ltr|ltr|RTL|Rtl|rtl)"
+            "match": "([Pp]ropagate|LTR|Ltr|ltr|RTL|Rtl|rtl|[Cc]leanup)"
         },
         "class-ref": {
             "name": "variable.other.class-ref.lexurgy",

--- a/syntaxes/lexurgy.tmLanguage.json
+++ b/syntaxes/lexurgy.tmLanguage.json
@@ -99,7 +99,7 @@
         },
         "rule-name": {
             "name": "entity.name.class.rule-name.lexurgy",
-            "match": "^[A-Za-z0-9]+(-([A-Za-z0-9]+))*(?=.*?:$)"
+            "match": "^[A-Za-z0-9]+(-([A-Za-z0-9]+))*(?=.*?:)"
         },
         "rule-control-flow": {
             "name": "keyword.control.rule-control-flow.lexurgy",

--- a/syntaxes/lexurgy.tmLanguage.json
+++ b/syntaxes/lexurgy.tmLanguage.json
@@ -40,7 +40,7 @@
                     "include": "#feature-binary"
                 }
             ],
-            "end": "\\n"
+            "end": "(?=#|\\n)"
         },
         "symbol": {
             "begin": "^([Ss]ymbol) ",
@@ -56,7 +56,7 @@
                     "include": "#matrix"
                 }
             ],
-            "end": "\\n"
+            "end": "(?=#|\\n)"
         },
         "diacritic": {
             "begin": "^([Dd]iacritic) ",
@@ -75,7 +75,7 @@
                     "include": "#matrix"
                 }
             ],
-            "end": "\\n"
+            "end": "(?=#|\\n)"
         },
         "class": {
             "begin": "^([Cc]lass) ",
@@ -91,7 +91,7 @@
                     "include": "#symbol-list"
                 }
             ],
-            "end": "\\n"
+            "end": "(?=#|\\n)"
         },
         "element": {
             "name": "keyword.other.element.lexurgy",


### PR DESCRIPTION
- Highlight the new "element" keyword
- Allow spaces and comments after rule names
- Allow comments after feature, diacritic or symbol declarations
- Allow keywords in rule names
- Highlight "cleanup" rule modifier